### PR TITLE
ktor sample - fix CWE-1104

### DIFF
--- a/samples/ktor-sureness/pom.xml
+++ b/samples/ktor-sureness/pom.xml
@@ -18,20 +18,6 @@
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <main.class>io.ktor.server.netty.EngineMain</main.class>
     </properties>
-    <repositories>
-        <repository>
-            <id>repo1</id>
-            <url>https://jcenter.bintray.com</url>
-            <releases><enabled>true</enabled></releases>
-            <snapshots><enabled>true</enabled></snapshots>
-        </repository>
-        <repository>
-            <id>repo2</id>
-            <url>https://kotlin.bintray.com/ktor</url>
-            <releases><enabled>true</enabled></releases>
-            <snapshots><enabled>true</enabled></snapshots>
-        </repository>
-    </repositories>
     <dependencies>
         <dependency>
             <groupId>com.usthe.sureness</groupId>


### PR DESCRIPTION
Using a deprecated artifact repository may eventually give attackers access for a supply chain attack.
