### PR TITLE
Fix spring-gateway-sureness running error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.2.6.RELEASE</version>
+                <version>2.4.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/sample-tom/pom.xml
+++ b/sample-tom/pom.xml
@@ -40,6 +40,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql.version}</version>

--- a/sample-tom/src/main/java/com/usthe/sureness/sample/tom/pojo/dto/Account.java
+++ b/sample-tom/src/main/java/com/usthe/sureness/sample/tom/pojo/dto/Account.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
 
 /**
  * @author tomsun28

--- a/samples/zuul-sureness/pom.xml
+++ b/samples/zuul-sureness/pom.xml
@@ -14,6 +14,19 @@
     <properties>
         <java.version>1.8</java.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.2.6.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
#116
* Bomp `spring-boot-dependencies` from 2.2.6.RELEASE to 2.4.5.
* Add `spring-boot-starter-validation` because of [validation starter no longer included in web starters from Spring Boot 2.3](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3-Release-Notes#validation-starter-no-longer-included-in-web-starters)
* Maintain the original dependency of `spring-cloud-starter-netflix-zuul`