### PR TITLE
Security Fix: Potential XSS Vulnerability in stripXss function

### DIFF
--- a/core/src/main/java/org/dromara/sureness/security/XssSqlUtil.java
+++ b/core/src/main/java/org/dromara/sureness/security/XssSqlUtil.java
@@ -45,11 +45,18 @@ public class XssSqlUtil {
     public static String stripXss(String value) {
         String rlt = null;
 
-        if (null != value) {
-            // NOTE: It's highly recommended to use the ESAPI library and uncomment the following line to
-            // avoid encoded attacks.
+        if (value != null) {
+            // Canonicalize input to handle encoded attacks
+            rlt = ESAPI.encoder().canonicalize(value);
 
-            rlt = value.replaceAll("", "");
+            // Avoid null characters
+            rlt = rlt.replaceAll("", "");
+
+            // Avoid "; sequences
+            rlt = rlt.replaceAll("\";", "");
+            rlt = rlt.replaceAll("';", "");
+            rlt = rlt.replaceAll("\"\\);", "");
+            rlt = rlt.replaceAll("'\\);", "");
 
             // Avoid anything between script tags
             rlt = SCRIPT1_PATTERN.matcher(rlt).replaceAll("");


### PR DESCRIPTION
This PR addresses a potential vulnerability in the stripXss() function in XssSqlUtil.java that could lead to Cross-Site Scripting (XSS) attacks because it does not use the ESAPI library for canonicalization which leaves it vulnerable to encoded attacks. This issue was originally reported and resolved in the repository via this commit https://github.com/logicaldoc/community/commit/739b005dbd09e0c7d82d431d174f83ac01a1a1d1.

**Fix**

- **Add Canonicalization**
    - Use the ESAPI library to canonicalize input before applying regex patterns

- **Include Additional Regex Patterns**
   - Add regex patterns to handle sequences like ";, ';, ");, and '); to prevent injection attacks that use these sequences to terminate or manipulate scripts

**References**
CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-Site Scripting')
CWE-116: Improper Encoding or Escaping of Output
https://github.com/logicaldoc/community/commit/739b005dbd09e0c7d82d431d174f83ac01a1a1d1